### PR TITLE
Summary statistics computed across all levels should use the reserved…

### DIFF
--- a/R/skim_v.R
+++ b/R/skim_v.R
@@ -111,7 +111,7 @@ skim_v_ <- function(x, FUNS) {
   lens <- purrr::map_int(values, length)
   stats <- purrr::map2(names(FUNS), lens, rep)
   nms <- purrr::map(values, ~names(.x))
-  level <- purrr::map_if(nms, is.null, ~NA)
+  level <- purrr::map_if(nms, is.null, ~".all")
   
   # Produce output
   tibble::tibble(type = class(x), 


### PR DESCRIPTION
… keyword ".all". This avoids confusion with the <NA> level and hopefully avoids potential naming clashes.