### PR TITLE
Make n_unique match its documentation.

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -22,7 +22,7 @@ factor_funs <- list(
   complete = n_complete,
   n = length,
   count = purrr::partial(table, useNA = "always"),
-  n_unique = purrr::compose(length, levels)
+  n_unique = n_unique
 )
 
 character_funs <- list (
@@ -32,7 +32,7 @@ character_funs <- list (
   min = min_char,
   max = max_char,
   empty = n_empty,
-  n_unique = purrr::compose(length, n_unique)
+  n_unique = n_unique
 )
 
 logical_funs <- list(
@@ -59,7 +59,7 @@ date_funs <- list(
   min = purrr::partial(min, na.rm = TRUE),
   max = purrr::partial(max, na.rm = TRUE),
   median = purrr::partial(median, na.rm = TRUE),
-  n_unique = purrr::compose(length, n_unique)
+  n_unique = n_unique
 )
 
 ts_funs <- list(
@@ -84,7 +84,7 @@ posixct_funs<-list(
   min = purrr::partial(min, na.rm = TRUE),
   max = purrr::partial(max, na.rm = TRUE),
   median = purrr::partial(median, na.rm = TRUE),
-  n_unique = purrr::compose(length, n_unique)  
+  n_unique = n_unique 
 )
 
 
@@ -92,7 +92,7 @@ asis_funs<-list(
   missing = n_missing,
   complete = n_complete,
   n = length,
-  n_unique = purrr::compose(length, n_unique),
+  n_unique = n_unique,
   min_length= list_min_length,
   max_length = list_max_length
 )
@@ -101,7 +101,7 @@ list_funs<-list(
   missing = n_missing,
   complete = n_complete,
   n = length,
-  n_unique = purrr::compose(length, n_unique),
+  n_unique = n_unique,
   min_length = list_lengths_min,
   median_length = list_lengths_median,
   max_length = list_lengths_max

--- a/R/stats.R
+++ b/R/stats.R
@@ -83,8 +83,8 @@ max_char <- function(x) {
 #' @export
 
 n_unique <- function(x) {
-  un <- unique(x)
-  un[!is.na(un)]
+  un <- x[!is.na(x)]
+  un <- unique(un)
   length(un)
 }
 

--- a/R/stats.R
+++ b/R/stats.R
@@ -85,6 +85,7 @@ max_char <- function(x) {
 n_unique <- function(x) {
   un <- unique(x)
   un[!is.na(un)]
+  length(un)
 }
 
 #' Get the start for a time series without the frequency


### PR DESCRIPTION
Currently the documentation for n_unique says it returns the number of unique values but it actually returns the vector of unique values, which is then composed with purrr to get the length.  This changes n_unique to include length() and return the number as described.  Also the PR changes the calls to n_unique to be direct rather than composed. 