### PR TITLE
Try shortening some labels (not for merging yet)

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -5,39 +5,39 @@ NULL
 # Default summarizing functions for each type -----------------------------
 
 numeric_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   mean = purrr::partial(mean, na.rm = TRUE),
   sd = purrr::partial(sd, na.rm = TRUE),
   min = purrr::partial(min, na.rm = TRUE),
-  median = purrr::partial(median, na.rm = TRUE),
-  quantile = purrr::partial(quantile, probs = c(.25, .75), na.rm = TRUE),
+  med = purrr::partial(median, na.rm = TRUE),
+  q = purrr::partial(quantile, probs = c(.25, .75), na.rm = TRUE),
   max = purrr::partial(max, na.rm = TRUE),
   hist = inline_hist
 )
 
 factor_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   count = purrr::partial(table, useNA = "always"),
-  n_unique = n_unique
+  unique = n_unique
 )
 
 character_funs <- list (
-  missing  = n_missing,
-  complete = n_complete,
+  NA.  = n_missing,
+  comp = n_complete,
   n = length,
   min = min_char,
   max = max_char,
   empty = n_empty,
-  n_unique = n_unique
+  unique = n_unique
 )
 
 logical_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   count = purrr::partial(table, useNA = "always"),
   mean = purrr::partial(mean, na.rm = TRUE)
@@ -47,28 +47,28 @@ integer_funs <- numeric_funs
 
 
 complex_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length
 )
 
 date_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   min = purrr::partial(min, na.rm = TRUE),
   max = purrr::partial(max, na.rm = TRUE),
-  median = purrr::partial(median, na.rm = TRUE),
-  n_unique = n_unique
+  med = purrr::partial(median, na.rm = TRUE),
+  unique = n_unique
 )
 
 ts_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   start = ts_start,
   end = ts_end,
-  frequency = stats::frequency,
+  freq = stats::frequency,
   deltat = stats::deltat,
   mean = purrr::partial(mean, na.rm = TRUE),
   sd = purrr::partial(sd, na.rm = TRUE),
@@ -79,30 +79,30 @@ ts_funs <- list(
 )
 
 posixct_funs<-list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
   min = purrr::partial(min, na.rm = TRUE),
   max = purrr::partial(max, na.rm = TRUE),
   median = purrr::partial(median, na.rm = TRUE),
-  n_unique = n_unique 
+  unique = n_unique 
 )
 
 
 asis_funs<-list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
-  n_unique = n_unique,
+  unique = n_unique,
   min_length= list_min_length,
   max_length = list_max_length
 )
 
 list_funs<-list(
-  missing = n_missing,
-  complete = n_complete,
+  NA. = n_missing,
+  comp = n_complete,
   n = length,
-  n_unique = n_unique,
+  unique = n_unique,
   min_length = list_lengths_min,
   median_length = list_lengths_median,
   max_length = list_lengths_max

--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -29,12 +29,12 @@ skim_print <- function(x){
 }
 
 formatnum <- function(x) {
-  tmp1 <- dplyr::mutate(x, stat = ifelse(stat == "quantile", 
+  tmp1 <- dplyr::mutate(x, stat = ifelse(stat == "q", 
                                paste(level, stat), stat))
   tmp1 <- dplyr::select(dplyr::filter(tmp1, stat != "hist"), -level)
   tmp1 <- dplyr::mutate(tmp1, stat = factor(stat, levels = c(
-    "missing", "complete", "n", "mean", "sd", "min", "25% quantile", "median",
-    "75% quantile", "max", "hist"
+    "NA.", "comp", "n", "mean", "sd", "min", "25% q", "med",
+    "75% q", "max", "hist"
   )))
   tmp1 <- tidyr::spread(tmp1, stat, value)
   
@@ -65,11 +65,11 @@ formatfct <- function(x) {
 }
 
 formatchars <- function(x) {
-  tmp1 <- dplyr::mutate(x, stat = ifelse(stat == "quantile", 
+  tmp1 <- dplyr::mutate(x, stat = ifelse(stat == "q", 
                                          paste(level, stat), stat))
   tmp1 <- dplyr::select(dplyr::filter(tmp1, stat != "hist"), -level)
   tmp1 <- dplyr::mutate(tmp1, stat = factor(stat, levels = c(
-    "complete","missing", "empty", "n", "min","max", "n_unique" 
+    "comp","NA.", "empty", "n", "min","max", "unique" 
   )))
   tmp1 <- tidyr::spread(tmp1, stat, value)
   


### PR DESCRIPTION
This shortens some of the labels.  Some of this will be treated differently in the refactored print but it's worth looking at now.  
Here are some of the complications.
- Some names like NA can't be used so in that case I used NA.
- Some names are constructed from `names()` associated with the variables, notably in quantiles. So I couldn't reduce it as far as we were discussing.
