### PR TITLE
Fixes #116 and #121

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -29,6 +29,7 @@ functions$current <- .default
 #' @return Nothing. \code{invisible(NULL)}
 #' @export
 #' @examples
+#' \dontrun{
 #' # Use new functions for numeric functions
 #' skim_with(numeric = list(median = median, mad = mad), append = FALSE)
 #' skim(faithful)
@@ -36,6 +37,7 @@ functions$current <- .default
 #' # Go back to defaults
 #' skim_with_defaults()
 #' skim(faithful)
+#' }
 
 skim_with <- function(..., append = TRUE) {
   # Argument assertions
@@ -62,7 +64,10 @@ set_functions <- function(type, newfuns, append) {
     message("Adding new summary functions for type: ", type)
   } else if (append) {
     old <- functions$current[[type]]
-    newfuns <- c(old, newfuns)
+    for (fn in names(newfuns)) {
+      old[[fn]] <- newfuns[[fn]]
+    }
+    newfuns <- old
   }
   
   functions$current[[type]] <- newfuns

--- a/R/functions.R
+++ b/R/functions.R
@@ -83,12 +83,26 @@ skim_with_defaults <- function() {
 #' a list. The names of the values in the list match the names of the classes
 #' that have assigned sets of summary functions.
 #' 
+#' @param which A character vector. One or more of the classes whose summary
+#'  functions you wish to display.
 #' @return A list. The names of the list match the classes that have assigned
 #'  summary functions.
 #' @export
 
-show_skimmers <- function() {
-  lapply(functions$current, names)
+show_skimmers <- function(which = NULL) {
+  stopifnot(is.null(which) || is.character(which))
+  skimmers <- lapply(functions$current, names)
+  if (is.null(which)) {
+    skimmers
+  } else {
+    out <- skimmers[which]
+    missed <- is.na(names(out))
+    if (any(missed)) {
+      warning("Skim functions aren't defined for type(s): ",
+              paste(which[missed], collapse = ", "))
+    }
+    out[!missed]
+  }
 }
 
 

--- a/man/show_skimmers.Rd
+++ b/man/show_skimmers.Rd
@@ -4,11 +4,18 @@
 \alias{show_skimmers}
 \title{Show summary functions currently used, by column type}
 \usage{
-show_skimmers()
+show_skimmers(which = NULL)
+}
+\arguments{
+\item{which}{A character vector. One or more of the classes whose summary
+functions you wish to display.}
 }
 \value{
-Nothing. \code{invisible()}
+A list. The names of the list match the classes that have assigned
+ summary functions.
 }
 \description{
-Show summary functions currently used, by column type
+The names of the summary functions are stored as a character vector within
+a list. The names of the values in the list match the names of the classes
+that have assigned sets of summary functions.
 }

--- a/man/skim_with.Rd
+++ b/man/skim_with.Rd
@@ -16,11 +16,36 @@ particular data type.}
 \item{append}{Whether the provided functions should be in addition to the
 defaults already in skim.}
 }
+\value{
+Nothing. \code{invisible(NULL)}
+}
 \description{
-Set or add the summary functions for a particular type of data
+While skim is designed around having an opinionated set of defaults, you
+can use this function to change the summary statistics that it returns.
+To do that, provide type you wish to change as an argument to this function,
+along with a list of named functions that you want to use instead of the
+defaults. The \code{append} argument lets you decide whether you want to
+replace the defaults or add to them.
+}
+\details{
+This function is not pure. It sets values in within the package environment.
+This is an intentional design choice, with effects similar to setting
+options in base R. By setting options here for your entire session, you
+can continue to summarize using skim on its own.
 }
 \section{Functions}{
 \itemize{
 \item \code{skim_with_defaults}: Use the default functions within skim
 }}
 
+\examples{
+\dontrun{
+# Use new functions for numeric functions
+skim_with(numeric = list(median = median, mad = mad), append = FALSE)
+skim(faithful)
+
+# Go back to defaults
+skim_with_defaults()
+skim(faithful)
+}
+}

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -85,18 +85,39 @@ correct <- tibble::tribble(
   "numeric",      "max",      ".all",       7.9,
   "numeric",      "hist",     "▂▇▅▇▆▆▅▂▂▂", 0,
   "numeric",      "iqr",      ".all",       IQR(iris$Sepal.Length),
-  "numeric",      "quantile", "99%",        7.7
+  "numeric",      "mad",      ".all",       mad(iris$Sepal.Length)
 )
 
-test_that("Skimming functions can be appended.", {
-  funs <- list(iqr = IQR,
-               quantile = purrr::partial(quantile, probs = .99))
-  skim_with(numeric = funs, append = TRUE)
+test_that("Skimming functions can be appended", {
+  funs <- list(iqr = IQR, mad = mad)
+  skim_with(numeric = funs)
   input <- skim_v(iris$Sepal.Length)
 
   # Restore defaults
   skim_with_defaults()
   expect_identical(input, correct)
+})
+
+correct <- tibble::tribble(
+  ~type,          ~stat,      ~level,       ~value,
+  "numeric",      "missing",  ".all",       0,
+  "numeric",      "complete", ".all",       150,
+  "numeric",      "n",        ".all",       150,
+  "numeric",      "mean",     ".all",       mean(iris$Sepal.Length),
+  "numeric",      "sd",       ".all",       sd(iris$Sepal.Length),
+  "numeric",      "min",      ".all",       4.3,
+  "numeric",      "median",   ".all",       5.8,
+  "numeric",      "quantile", "99%",        7.7,
+  "numeric",      "max",      ".all",       7.9,
+  "numeric",      "hist",     "▂▇▅▇▆▆▅▂▂▂", 0,
+  "numeric",      "iqr",      ".all",       IQR(iris$Sepal.Length)
+)
+
+test_that("When append = FALSE, skimmers are replaced", {
+  newfuns <- list(iqr = IQR,
+                  quantile = purrr::partial(quantile, probs = .99))
+  skim_with(numeric = newfuns, append = TRUE)
+  input <- skim_v(iris$Sepal.Length)
 })
 
 correct <- tibble::tribble(
@@ -118,13 +139,13 @@ test_that("Skimming functions for new types can be added", {
 })
 
 correct <- tibble::tribble(
-  ~type,          ~stat,      ~level,   ~value,
-  "new_type",     "iqr",      ".all",   IQR(iris$Sepal.Length),
+  ~type,          ~stat,      ~level,  ~value,
+  "new_type",     "iqr",      ".all",  IQR(iris$Sepal.Length),
   "new_type",     "quantile", "99%",   7.7,
   "new_type",     "q2",       "99%",   7.7
 )
 
-test_that("Set multiple sets of skimming functions", {
+test_that("Set skimming functions for multiple types", {
   funs <- list(iqr = IQR,
     quantile = purrr::partial(quantile, probs = .99),
     q2 = purrr::partial(quantile, probs = .99))

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -8,12 +8,40 @@ test_that("show_skimmers() has a correct list of functions for a type", {
   identical(input, correct)
 })
 
-test_that("show_skimmers() has a correct list of types", {
-  correct <- c("numeric",   "integer",  "factor" ,   "ordered",   "character", "logical",   "complex",
-               "date",      "Date",      "ts", "POSIXct" )
+test_that("show_skimmers() has a correct list of default types", {
+  correct <- c("numeric", "integer", "factor" , "character", "logical",
+               "complex", "date", "Date", "ts", "POSIXct" )
   skimmers <- show_skimmers()
   input <- names(skimmers)
   identical(input, correct)
+})
+
+test_that("show_skimmers() lets you pick which type you want returned", {
+  correct <- list(character = c("missing", "complete", "n", "min", "max",
+                                "empty", "n_unique"))
+  skimmers <- show_skimmers("character")
+  expect_identical(correct, skimmers)
+})
+
+test_that("show_skimmers() lets you pick which many types you want returned", {
+  correct <- list(numeric = c("missing", "complete", "n", "mean",  "sd", "min",
+                              "median", "quantile", "max", "hist"),
+                  character = c("missing",  "complete", "n", "min", "max",
+                                "empty", "n_unique"))
+  skimmers <- show_skimmers(c("numeric", "character"))
+  expect_identical(correct, skimmers)
+})
+
+test_that("show_skimmers() throws a warning when given an unassigned type", {
+  expect_warning(skimmers <- show_skimmers("banana"), "aren't defined")
+  expect_identical(skimmers, setNames(list(), character(0)))
+})
+
+test_that("show_skimmers() returns something if given an unassigned type", {
+  expect_warning(skimmers <- show_skimmers(c("character", "banana")))
+  correct <- list(character = c("missing", "complete", "n", "min", "max",
+                                "empty", "n_unique"))
+  expect_identical(skimmers, correct)
 })
 
 test_that("Skimmer list is updated correctly when changing functions", {
@@ -27,9 +55,9 @@ test_that("Skimmer list is updated correctly when changing functions", {
 })
 
 correct <- tibble::tribble(
-  ~type,          ~stat,  ~level,   ~value,
-  "numeric",      "iqr",  ".all",   IQR(iris$Sepal.Length),
-  "numeric", "quantile",   "99%",   7.7
+  ~type,     ~stat,      ~level,  ~value,
+  "numeric", "iqr",      ".all",  IQR(iris$Sepal.Length),
+  "numeric", "quantile", "99%",   7.7
 )
 
 test_that("Skimming functions can be changed for different types", {
@@ -44,20 +72,20 @@ test_that("Skimming functions can be changed for different types", {
 })
 
 correct <- tibble::tribble(
-  ~type,          ~stat,    ~level,   ~value,
-  "numeric",      "missing", ".all",   0,
-  "numeric",      "complete",".all",   150,
-  "numeric",      "n",       ".all",   150,
-  "numeric",      "mean",    ".all",   mean(iris$Sepal.Length),
-  "numeric",      "sd",      ".all",   sd(iris$Sepal.Length),
-  "numeric",      "min",     ".all",   4.3,
-  "numeric",      "median",  ".all",   5.8,
-  "numeric",      "quantile","25%",    5.1,
-  "numeric",      "quantile","75%",    6.4,
-  "numeric",      "max",     ".all",   7.9,
-  "numeric",      "hist", "▂▇▅▇▆▆▅▂▂▂",0,              
-  "numeric",      "iqr",     ".all",   IQR(iris$Sepal.Length),
-  "numeric",      "quantile","99%",    7.7
+  ~type,          ~stat,      ~level,       ~value,
+  "numeric",      "missing",  ".all",       0,
+  "numeric",      "complete", ".all",       150,
+  "numeric",      "n",        ".all",       150,
+  "numeric",      "mean",     ".all",       mean(iris$Sepal.Length),
+  "numeric",      "sd",       ".all",       sd(iris$Sepal.Length),
+  "numeric",      "min",      ".all",       4.3,
+  "numeric",      "median",   ".all",       5.8,
+  "numeric",      "quantile", "25%",        5.1,
+  "numeric",      "quantile", "75%",        6.4,
+  "numeric",      "max",      ".all",       7.9,
+  "numeric",      "hist",     "▂▇▅▇▆▆▅▂▂▂", 0,
+  "numeric",      "iqr",      ".all",       IQR(iris$Sepal.Length),
+  "numeric",      "quantile", "99%",        7.7
 )
 
 test_that("Skimming functions can be appended.", {
@@ -73,8 +101,8 @@ test_that("Skimming functions can be appended.", {
 
 correct <- tibble::tribble(
   ~type,          ~stat,  ~level,   ~value,
-  "new_type",      "iqr",  ".all",   IQR(iris$Sepal.Length),
-  "new_type", "quantile",   "99%",   7.7
+  "new_type",      "iqr", ".all",   IQR(iris$Sepal.Length),
+  "new_type", "quantile",  "99%",   7.7
 )
 
 test_that("Skimming functions for new types can be added", {
@@ -90,10 +118,10 @@ test_that("Skimming functions for new types can be added", {
 })
 
 correct <- tibble::tribble(
-  ~type,          ~stat,  ~level,   ~value,
-  "new_type",      "iqr",  ".all",   IQR(iris$Sepal.Length),
-  "new_type", "quantile",   "99%",   7.7,
-  "new_type", "q2",   "99%",   7.7
+  ~type,          ~stat,      ~level,   ~value,
+  "new_type",     "iqr",      ".all",   IQR(iris$Sepal.Length),
+  "new_type",     "quantile", "99%",   7.7,
+  "new_type",     "q2",       "99%",   7.7
 )
 
 test_that("Set multiple sets of skimming functions", {
@@ -118,5 +146,3 @@ test_that("Throw errors when arguments are incorrect", {
   # Restore defaults
   skim_with_defaults()
 })
-
-skim_with_defaults()


### PR DESCRIPTION
Give users the option of selecting which summary functions are returned by show_skimmers. It does this by accepting an argument for a data type/ class.

For example skim_with("numeric") gives the names of functions used to summarize numeric data.