### PR TITLE
Fixes #83

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -37,6 +37,11 @@ functions$current <- .default
 #' # Go back to defaults
 #' skim_with_defaults()
 #' skim(faithful)
+#' 
+#' # If you want to remove a particular skimmer, set it to NULL
+#' # This removes the inline histogram
+#' skim_with(numeric = list(hist = NULL))
+#' skim(faithful)
 #' }
 
 skim_with <- function(..., append = TRUE) {

--- a/man/skim_with.Rd
+++ b/man/skim_with.Rd
@@ -47,5 +47,10 @@ skim(faithful)
 # Go back to defaults
 skim_with_defaults()
 skim(faithful)
+
+# If you want to remove a particular skimmer, set it to NULL
+# This removes the inline histogram
+skim_with(numeric = list(hist = NULL))
+skim(faithful)
 }
 }

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -54,6 +54,14 @@ test_that("Skimmer list is updated correctly when changing functions", {
   skim_with_defaults()
 })
 
+test_that("Skim functions can be removed by setting them to NULL", {
+  skim_with(numeric = list(hist = NULL))
+  correct <- list(numeric = c("missing", "complete", "n", "mean",  "sd", "min",
+                              "median", "quantile", "max"))
+  input <- show_skimmers("numeric")
+  expect_identical(correct, input)
+})
+
 correct <- tibble::tribble(
   ~type,     ~stat,      ~level,  ~value,
   "numeric", "iqr",      ".all",  IQR(iris$Sepal.Length),


### PR DESCRIPTION
You can now remove skimming functions by setting them to NULL in skim_with.