### PR TITLE
typo and posixct simplification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ requests, note that in your issue comments.
 
 ## Code style
 
-Please use nake case (such as skim_v)  for function names.  Besides that, in general follow the Google code 
+Please use snake case (such as skim_v)  for function names.  Besides that, in general follow the Google code 
 style for R.
 
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -201,15 +201,7 @@ ts_funs <- list(
   line_graph  = inline_linegraph
 )
 
-posixct_funs <- list(
-  missing = n_missing,
-  complete = n_complete,
-  n = length,
-  min = purrr::partial(min, na.rm = TRUE),
-  max = purrr::partial(max, na.rm = TRUE),
-  median = purrr::partial(median, na.rm = TRUE),
-  n_unique = n_unique 
-)
+posixct_funs <- date_funs
 
 asis_funs <- list(
   missing = n_missing,


### PR DESCRIPTION
Two things:
I noticed that "nake_case" should be "snake_case" when reading the contributing file. 

In my other pull request @elinw mentioned that it would be cleaner to assign posixct_funs to date_funs since they are identical (I was not sure if it was better to keep that separate from the other PR or to put it here. Happy to swap it to the other one if that would be preferred).