### PR TITLE
Fix note due to global variable

### DIFF
--- a/R/skim.R
+++ b/R/skim.R
@@ -37,7 +37,7 @@ skim.grouped_df <- function(.data) {
   
   # Drop the grouping variable
   groups <- dplyr::groups(skimmed)
-  to_drop <- rlang::quo(!(variable %in% groups))
+  to_drop <- quote(!(variable %in% groups))
   skimmed <- dplyr::filter(skimmed, !!to_drop)
   structure(skimmed, class = c("skim_df", class(skimmed)),
             data_rows = nrow(.data), data_cols = ncol(.data))


### PR DESCRIPTION
R CMD check doesn't currently respect quoting within rlang::quo.
Use base R quote instead.