### PR TITLE
add na.rm = TRUE to fix #255

### DIFF
--- a/R/stats.R
+++ b/R/stats.R
@@ -52,7 +52,7 @@ inline_hist <- function(x) {
   }
 
   # Addresses a known bug in cut()
-  if (all(x == 0)) x <- x + 1
+  if (all(x == 0, na.rm = TRUE)) x <- x + 1
   hist_dt <- table(cut(x, options$formats$character$width))
   hist_dt <- hist_dt / max(hist_dt)
   structure(spark_bar(hist_dt), class = c("spark", "character"))

--- a/tests/testthat/test-skim_v.R
+++ b/tests/testthat/test-skim_v.R
@@ -237,7 +237,7 @@ test_that("skim_v returns expected response for POSIXct vectors", {
 })
 
 test_that("skim_v returns expected response for list (not AsIs) vectors", {
-  correct <- tibble::tribble (
+  correct <- tibble::tribble(
     ~type,    ~stat,           ~level,  ~value, ~formatted,
     "list",   "missing",        ".all",  1L,     "1",
     "list",   "complete",       ".all",  5L,     "5",
@@ -258,7 +258,7 @@ test_that("skim_v returns expected response for list (not AsIs) vectors", {
 })
 
 test_that("skimr:::skim_v returns expected response for list with all NA's", {
-  correct <- tibble::tribble (
+  correct <- tibble::tribble(
     ~type,    ~stat,           ~level,  ~value, ~formatted,
     "list",   "missing",       ".all",   3L,     "3",
     "list",   "complete",      ".all",   0L,     "0",
@@ -329,5 +329,24 @@ test_that("numeric skim is calculated correctly when x is all NAs.", {
     "numeric",      "p75",   ".all", NA,                   "NA",         "x",
     "numeric",      "p100",  ".all", NA,                    "NA",         "x",
     "numeric",     "hist",   ".all", NA,                   " ",         "x" )
+  expect_identical(input[1:6], correct[1:6])
+})
+
+test_that("numeric skim is calculated correctly when x is all zeores or NAs.", {
+  x <- as.numeric(c(NA, NA, NA, 0))
+  input <- skim(x)
+  correct <- tibble::tribble(
+    ~type,          ~stat, ~level,   ~value,              ~ formatted, ~variable,
+    "numeric",  "missing",   ".all", 3,                   "3",         "x",
+    "numeric", "complete",   ".all", 1,                   "1",         "x",
+    "numeric",        "n",   ".all", 4,                   "4",         "x",
+    "numeric",     "mean",   ".all", 0,                   "0",         "x",
+    "numeric",       "sd",   ".all", NA,                  "NA",         "x", 
+    "numeric",      "p0",   ".all",  0,                   "0",         "x",
+    "numeric",      "p25",   ".all", 0,                   "0",         "x",
+    "numeric",   "median",   ".all", 0,                   "0",         "x",
+    "numeric",      "p75",   ".all", 0,                   "0",         "x",
+    "numeric",      "p100",  ".all", 0,                   "0",         "x",
+    "numeric",     "hist",   ".all", NA,  "▁▁▁▇▁▁▁▁",         "x" )
   expect_identical(input[1:6], correct[1:6])
 })

--- a/tests/testthat/test-stats.R
+++ b/tests/testthat/test-stats.R
@@ -59,6 +59,13 @@ test_that("inline histogram is calculated correctly when x is all zeros.", {
   expect_identical(input, correct)
 })
 
+test_that("inline histogram is calculated correctly when x is all zeores or
+          NAs", {
+            input <- inline_hist(as.numeric(c(NA, NA, NA, 0, 0)))
+            correct <- structure("▁▁▁▇▁▁▁▁", class = c("spark", "character"))
+            expect_identical(input, correct)
+          })
+
 test_that("inline histogram is calculated correctly when x is all 1s.", {
   input <- inline_hist(numeric(1))
   correct <- structure("▁▁▁▇▁▁▁▁", class = c("spark", "character"))


### PR DESCRIPTION
This should fix #255 :

``` r
library(skimr)
a = data.frame(var = c(0,0,0,NA))
skim(a)
#> Skim summary statistics
#>  n obs: 4 
#>  n variables: 1 
#> 
#> Variable type: numeric 
#>  variable missing complete n mean sd p0 p25 median p75 p100     hist
#>       var       1        3 4    0  0  0   0      0   0    0 <U+2581><U+2581><U+2581><U+2587><U+2581><U+2581><U+2581><U+2581>
```
