### PR TITLE
Allow histogram with infinite values

### DIFF
--- a/R/stats.R
+++ b/R/stats.R
@@ -45,13 +45,15 @@ sorted_count <- function(x) {
 #' @export
 
 inline_hist <- function(x) {
-  # Handle empty and NA vectors (is.finite is FALSE for NA, NaN, and +/-Inf)
-  if (length(x) < 1|| !any(is.finite(x)))
+  # For the purposes of the histogram, treat infinite as NA
+  # (before the test for all NA)
+  x[is.infinite(x)] <- NA
+  
+  # Handle empty and NA vectors (is.na is TRUE for NaN)
+  if (length(x) < 1 || all(is.na(x)))
   {
     return(structure(" ", class = c("spark", "character")))
   }
-  # cut() doesn't handle infinite values well
-  x <- x[is.finite(x)]
 
   # Addresses a known bug in cut()
   if (all(x == 0, na.rm = TRUE)) x <- x + 1

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -2,26 +2,26 @@ context("Skim a data.frame")
 
 test_that("Skimming a data frame works as expected", {
   input <- skim(chickwts)
-  
+
   # dimensions
   expect_length(input, 6)
   expect_equal(nrow(input), 23)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "tbl_df")
   expect_is(input, "tbl")
   expect_is(input, "data.frame")
-  expect_identical(input$variable, c(rep(c("weight"), each = 11), 
+  expect_identical(input$variable, c(rep(c("weight"), each = 11),
                                 rep("feed", each = 12)))
-  expect_identical(input$type, c(rep("numeric", each = 11), 
+  expect_identical(input$type, c(rep("numeric", each = 11),
                                  rep("factor", each = 12)))
   expect_identical(head(input$stat),
                    c("missing", "complete", "n", "mean", "sd", "p0"))
   expect_identical(tail(input$stat), c(rep("top_counts", 5), rep("ordered", 1)))
   expect_identical(head(input$level), rep(".all", 6))
   expect_identical(tail(input$level),
-                   c("linseed", "sunflower", "meatmeal", 
+                   c("linseed", "sunflower", "meatmeal",
                      "horsebean", NA, ".all"  ))
   expect_equal(head(input$value), c(0, 71, 71, 261.3, 78.1, 108), tol = .01)
   expect_equal(tail(input$value), c( 12, 12, 11, 10, 0, 0))
@@ -46,18 +46,18 @@ test_that("Using skim_tee prints out the object", {
 
 test_that("Skimming a grouped data frame works as expected", {
   input <- dplyr::group_by(mtcars, cyl, gear) %>% skim()
-  
+
   # dimensions
   expect_length(input, 8)
   expect_equal(nrow(input), 792)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "grouped_df")
   expect_is(input, "tbl_df")
   expect_is(input, "tbl")
   expect_is(input, "data.frame")
-  
+
   # values
   expect_identical(input$cyl, rep(c(4, 6, 8), c(297, 297, 198)))
   expect_true(all(c(3, 4, 5) %in% input$gear))
@@ -79,10 +79,10 @@ test_that("skim_to_wide works as expected.", {
   expect_length(input, 16)
   expect_equal(nrow(input), 5)
   expect_identical(input$type, c("factor", rep("numeric", each = 4)))
-  expect_identical(input$variable, 
+  expect_identical(input$variable,
     c("Species", "Petal.Length", "Petal.Width", "Sepal.Length", "Sepal.Width"))
   expect_identical(input$n, rep("150", each = 5))
-  expect_identical(input$top_counts, c("set: 50, ver: 50, vir: 50, NA: 0", 
+  expect_identical(input$top_counts, c("set: 50, ver: 50, vir: 50, NA: 0",
                                        NA, NA, NA, NA))
 })
 
@@ -93,7 +93,7 @@ test_that("skim_to_list works as expected", {
   expect_identical(class(input), "list")
   expect_identical(class(input[["numeric"]]), c("tbl", "tbl_df", "data.frame"))
   expect_equal(dim(input[["numeric"]]), c(1, 12))
-  expect_identical(names(input[["numeric"]]), 
+  expect_identical(names(input[["numeric"]]),
                    c("variable", "missing", "complete", "n", "mean",
                      "sd", "p0", "p25", "median", "p75", "p100", "hist" ))
 })
@@ -103,7 +103,7 @@ test_that("skim_to_list works with grouped data", {
   input <- skim_to_list(xg)
   expect_length(input,1)
   expect_equal(dim(input[["numeric"]]), c(30,13))
-})  
+})
 
 test_that("Skimming a vector works as expected", {
   input <- skim(lynx)
@@ -123,7 +123,7 @@ test_that("Skimming a vector works as expected", {
   expect_identical(input$variable, c(rep(c("lynx"), each = 13)))
   expect_equal(head(input$value), c(0, 114, 114, 1821, 1934, 1), tol = .01)
   expect_identical(head(input$formatted),
-                   c("0", "114", "114", "1821", "1934", "1"))  
+                   c("0", "114", "114", "1821", "1934", "1"))
 })
 
 test_that("Skimming a column of a data frame works as expected", {
@@ -145,18 +145,18 @@ test_that("Skimming a column of a data frame works as expected", {
                    c("0", "71", "71", "261.31", "78.07", "108"))
 })
 
-test_that("Skimming an object without a method returns the appropriate 
+test_that("Skimming an object without a method returns the appropriate
           messsage", {
   expect_message(skim(volcano), "No skim method exists for class matrix")
 })
 
 test_that("Skimming a data frame with selected columns works as expected", {
   input <- skim(chickwts, weight)
-  
+
   # dimensions
   expect_length(input, 6)
   expect_equal(nrow(input), 11)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "tbl_df")
@@ -174,17 +174,17 @@ test_that("Skimming a data frame with selected columns works as expected", {
 
 test_that("You can use tidyselect negation", {
   input <- skim(chickwts, -weight)
-  
+
   # dimensions
   expect_length(input, 6)
   expect_equal(nrow(input), 12)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "tbl_df")
   expect_is(input, "tbl")
   expect_is(input, "data.frame")
-  
+
   # Content
   expect_identical(input$variable, rep("feed", 12))
   expect_identical(input$type, rep("factor", 12))
@@ -199,17 +199,17 @@ test_that("You can use tidyselect negation", {
 
 test_that("Tidyselect helpers work as expected", {
   input <- skim(iris, starts_with("Sepal"))
-  
+
   # dimensions
   expect_length(input, 6)
   expect_equal(nrow(input), 22)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "tbl_df")
   expect_is(input, "tbl")
   expect_is(input, "data.frame")
-  
+
   # Content
   expect_identical(input$variable, rep(c("Sepal.Length", "Sepal.Width"),
                                        each = 11))
@@ -224,18 +224,18 @@ test_that("Tidyselect helpers work as expected", {
 
 test_that("Skimming a grouped df works as expected selecting two columns", {
   input <- dplyr::group_by(mtcars, cyl, gear) %>% skim(mpg, disp)
-  
+
   # dimensions
   expect_length(input, 8)
   expect_equal(nrow(input), 176)
-  
+
   # classes
   expect_is(input, "skim_df")
   expect_is(input, "grouped_df")
   expect_is(input, "tbl_df")
   expect_is(input, "tbl")
   expect_is(input, "data.frame")
-  
+
   # values
   expect_identical(input$cyl, rep(c(4, 6, 8), c(66, 66, 44)))
   expect_true(all(c(3, 4, 5) %in% input$gear))
@@ -250,3 +250,9 @@ test_that("Skimming a grouped df works as expected selecting two columns", {
   expect_identical(input$formatted[1:5], c("0", "1", "1", "21.5", "NA"))
 })
 
+test_that("Skimming with non-finite values works", {
+  expect_length(skim(data.frame(x = c(0, 1, NA))), 6)
+  expect_length(skim(data.frame(x = c(0, NA))), 6)
+  expect_length(skim(data.frame(x = c(-Inf, 0))), 6)
+  expect_length(skim(data.frame(x = c(0, Inf))), 6)
+})

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -256,3 +256,9 @@ test_that("Skimming with non-finite values works", {
   expect_length(skim(data.frame(x = c(-Inf, 0))), 6)
   expect_length(skim(data.frame(x = c(0, Inf))), 6)
 })
+
+test_that("inline histogram is calculated correctly with Inf.", {
+  input <- inline_hist(c(1, 2, 3, 3, 6, 6, 6, 8, Inf, -Inf))
+  correct <- structure("▂▂▅▁▁▇▁▂", class = c("spark", "character"))
+  expect_identical(input, correct)
+})


### PR DESCRIPTION
Thanks for the great package!

I encountered a few issues when I was trying to skim a dataframe with infinite values, so I wrote a quick PR. Let me know if I should make any changes!

- Replace `seq(..., length = )` with `seq(..., length.out = )` to exactly match the argument (courtesy of [strict](https://github.com/hadley/strict/))
- Fix issues with histograms of infinite or NA values
- Add tests for those histograms
- Remove a bunch of trailing whitespaces because of Atom