### PR TITLE
An empty function list for a class should not cause an error and should eliminate that class 

### DIFF
--- a/R/skim.R
+++ b/R/skim.R
@@ -110,6 +110,9 @@ skim.default <-function(.data, ...){
     return(message("No skim method exists for class ", class(.data), "."))
   }
   skimmed <- skim_v(.data)
+  if (is.null(skimmed)){
+    return(message("The skimmer list is empty for class ", class(.data), "."))
+  }
   skimmed$variable <- deparse(substitute(.data))
   cols <- c("variable", "type", "stat", "level", "value", "formatted")
   skimmed <- dplyr::select(skimmed, !!!rlang::syms(cols)) 

--- a/R/skim_v.R
+++ b/R/skim_v.R
@@ -16,7 +16,10 @@ skim_v <- function(x, vector_type = class(x)) {
   stopifnot(length(x) > 0,
             is.character(vector_type))
   funs <- get_funs(vector_type)
-
+  # An empty list returns nothing
+  if (!is.null(funs) && length(funs) == 0  ){
+    return(NULL)
+  }
   if (is.null(funs)) {
     collapsed <- paste(class(x), collapse = ", ")
     msg <- paste("No summary functions for vectors of class:", collapsed)

--- a/man/kable.Rd
+++ b/man/kable.Rd
@@ -17,40 +17,40 @@ kable(x, format = NULL, digits = getOption("digits"), row.names = NA,
 \method{kable}{summary_skim_df}(x, ...)
 }
 \arguments{
-\item{x}{an R object (typically a matrix or data frame)}
+\item{x}{An R object, typically a matrix or data frame.}
 
-\item{format}{a character string; possible values are \code{latex},
+\item{format}{A character string. Possible values are \code{latex},
 \code{html}, \code{markdown}, \code{pandoc}, and \code{rst}; this will be
 automatically determined if the function is called within \pkg{knitr}; it
-can also be set in the global option \code{knitr.table.format}; if
-\code{format} is a function, it must return a character string}
+can also be set in the global option \code{knitr.table.format}. If
+\code{format} is a function, it must return a character string.}
 
-\item{digits}{the maximum number of digits for numeric columns (passed to
-\code{round()}); it can also be a vector of length \code{ncol(x)} to set
-the number of digits for individual columns}
+\item{digits}{Maximum number of digits for numeric columns, passed to
+\code{round()}. This can also be a vector of length \code{ncol(x)}, to set
+the number of digits for individual columns.}
 
-\item{row.names}{a logical value indicating whether to include row names; by
+\item{row.names}{Logical: whether to include row names. By
 default, row names are included if \code{rownames(x)} is neither
-\code{NULL} nor identical to \code{1:nrow(x)}}
+\code{NULL} nor identical to \code{1:nrow(x)}.}
 
-\item{col.names}{a character vector of column names to be used in the table}
+\item{col.names}{A character vector of column names to be used in the table.}
 
-\item{align}{the alignment of columns: a character vector consisting of
-\code{'l'} (left), \code{'c'} (center) and/or \code{'r'} (right); by
-default, numeric columns are right-aligned, and other columns are
-left-aligned; if \code{align = NULL}, the default alignment is used;
-alternatively, if \code{length(align) == 1L}, the string will be expanded
-to a vector of individual letters unless the output format is LaTeX; for
-example, \code{'clc'} will be converted to \code{c('c', 'l', 'c')}}
+\item{align}{Column alignment: a character vector consisting of
+ \code{'l'} (left), \code{'c'} (center) and/or \code{'r'} (right). By
+ default or if \code{align = NULL}, numeric columns are right-aligned, and
+ other columns are left-aligned. If \code{length(align) == 1L}, the string will be
+ expanded to a vector of individual letters, e.g. \code{'clc'} becomes
+\code{c('c', 'l', 'c')}, unless the output format is LaTeX.}
 
-\item{caption}{the table caption}
+\item{caption}{The table caption.}
 
-\item{format.args}{a list of arguments to be passed to \code{\link{format}()}
-to format table values, e.g. \code{list(big.mark = ',')}}
+\item{format.args}{A list of arguments to be passed to \code{\link{format}()}
+to format table values, e.g. \code{list(big.mark = ',')}.}
 
-\item{escape}{escape special characters when producing HTML or LaTeX tables}
+\item{escape}{Boolean; whether to escape special characters when producing
+HTML or LaTeX tables.}
 
-\item{...}{other arguments (see examples)}
+\item{...}{Other arguments (see Examples).}
 }
 \value{
 The original \code{skim_df} object.

--- a/man/skim_format.Rd
+++ b/man/skim_format.Rd
@@ -63,7 +63,7 @@ For each data type, options are returned as a list of option-value pairs.
 skim_format(numeric = list(digits = 3))
 
 # Show the values for the formats
-show_formats
+show_formats()
 
 # Show 4-character names in factor levels
 skim_format(.levels = list(max_char = 4))
@@ -72,8 +72,11 @@ skim_format(.levels = list(max_char = 4))
 skim_format(numeric = list(digits = 3), .levels = list(max_char = 4))
 
 # Set multiple formats with a .list argument
-myFormats <- list(numeric = list(digits = 3), .levels = list(max_char = 4))
-skim_format(.list = myFormats)
+my_formats <- list(numeric = list(digits = 3), .levels = list(max_char = 4))
+skim_format(.list = my_formats)
+
+# Alternatively, use rlang unquoting semantics
+skim_format(!!!my_formats)
 
 # Reset to the defaults
 skim_format_defaults()

--- a/man/skim_with.Rd
+++ b/man/skim_with.Rd
@@ -90,8 +90,11 @@ skim_with(numeric = list(mean = mean), character = list(len = length))
 
 # Or pass the same as a list
 my_skimmers <- list(numeric = list(mean = mean),
-                   character = list(len = length))
+                    character = list(len = length))
 skim_with(.list = my_skimmers)
+
+# Alternatively, use rlang unquoting semantics
+skim_with(!!!my_skimmers)
 
 # Go back to defaults
 skim_with_defaults()

--- a/tests/testthat/test-functions.R
+++ b/tests/testthat/test-functions.R
@@ -136,6 +136,17 @@ test_functions_that("Set multiple sets of skimming functions, rlang", {
   skim_with_defaults()
 })
 
+test_that("A class with an empty function list returns nothing",{
+  myfuns <- list(factor = list())
+  skim_with(!!!myfuns, append= FALSE)
+  input <- skim(iris)
+  expect_equal(nrow(input), 44)
+  inputlist <- skim_to_list(iris)
+  expect_equal(length(inputlist), 1)
+  expect_equal(names(inputlist), c("numeric"))
+  skim_with_defaults()
+})
+
 test_functions_that("Skimming functions without a class return a message.", {
   funs_no_class <- list( IQR)
   expect_error(skim_with(funs_no_class), "Please used named arguments")
@@ -317,4 +328,10 @@ test_functions_that("Defines skimmers using rlang-style formula lambdas", {
   input_funs <- get_skimmers()
   expect_identical(input$numeric, names(funs))
   expect_identical(input_funs$numeric, purrr::map(funs, rlang::as_function))
+})
+
+test_that("Setting skimmers to an empty list does not throw an error",{
+  expect_silent(skim_with(factor=list(), append=FALSE))
+  expect(is.null(show_skimmers()$factor))
+  skim_with_defaults()
 })

--- a/tests/testthat/test-skim_v.R
+++ b/tests/testthat/test-skim_v.R
@@ -384,3 +384,11 @@ test_that("Skimming with non-finite values works", {
   expect_warning(input<-skim(c(x = c(-Inf, 0))))
   expect_length(input, 6)
 })
+
+test_that("Skimming with an empty function list for a class 
+          returns the expected message",{
+  skim_with(factor=list(), append=FALSE)
+  expect_message(skim(iris$Species), 
+                 "The skimmer list is empty for class factor.")
+  skim_with_defaults()
+})


### PR DESCRIPTION
from the skim results. For a single vector a message indicates that there is not a skimmer for that class.  This is deliberately different handling than for the case where a given class does not exist at all (in which case skim() falls back to character). 